### PR TITLE
update AWS blog list

### DIFF
--- a/aws-blog-youtube-podcast.opml
+++ b/aws-blog-youtube-podcast.opml
@@ -4,29 +4,41 @@
         <outline text="Amazon Blog" title="Amazon blog">
             <outline type="rss" text="AWS News Blog" title="AWS News Blog" htmlUrl="https://aws.amazon.com/blogs/aws/" xmlUrl="https://aws.amazon.com/blogs/aws/feed" />
             <outline type="rss" text="AWS Architecture Blog" title="AWS Architecture Blog" htmlUrl="https://aws.amazon.com/blogs/architecture/" xmlUrl="https://aws.amazon.com/blogs/architecture/feed" />
+            <outline type="rss" text="AWS Cost Management" title="AWS Cost Management" htmlUrl="https://aws.amazon.com/blogs/aws-cost-management/" xmlUrl="https://aws.amazon.com/blogs/aws-cost-management/feed"/>
             <outline type="rss" text="AWS Partner Network (APN) Blog" title="AWS Partner Network (APN) Blog" htmlUrl="https://aws.amazon.com/blogs/apn/" xmlUrl="https://aws.amazon.com/blogs/apn/feed" />
             <outline type="rss" text="AWS Marketplace" title="AWS Marketplace" htmlUrl="https://aws.amazon.com/blogs/awsmarketplace/" xmlUrl="https://aws.amazon.com/blogs/awsmarketplace/feed" />
             <outline type="rss" text="AWS Big Data Blog" title="AWS Big Data Blog" htmlUrl="https://aws.amazon.com/blogs/big-data/" xmlUrl="https://aws.amazon.com/blogs/big-data/feed" />
+            <outline type="rss" text="Business Productivity" title="Business Productivity" htmlUrl="https://aws.amazon.com/blogs/business-productivity/" xmlUrl="https://aws.amazon.com/blogs/business-productivity/feed"/>
             <outline type="rss" text="AWS Compute Blog" title="AWS Compute Blog" htmlUrl="https://aws.amazon.com/blogs/compute/" xmlUrl="https://aws.amazon.com/blogs/compute/feed" />
+            <outline type="rss" text="Contact Center" title="Contact Center" htmlUrl="https://aws.amazon.com/blogs/contact-center/" xmlUrl="https://aws.amazon.com/blogs/contact-center/feed"/>
+            <outline type="rss" text="Containers" title="Containers" htmlUrl="https://aws.amazon.com/blogs/containers/" xmlUrl="https://aws.amazon.com/blogs/containers/feed"/>
             <outline type="rss" text="AWS Database Blog" title="AWS Database Blog" htmlUrl="https://aws.amazon.com/blogs/database/" xmlUrl="https://aws.amazon.com/blogs/database/feed" />
-            <outline type="rss" text="AWS Desktop and Application Streaming Blog" title="AWS Desktop and Application Streaming Blog" htmlUrl="https://aws.amazon.com/blogs/desktop-and-application-streaming/" xmlUrl="https://aws.amazon.com/blogs/desktop-and-application-streaming/feed" />
-            <outline type="rss" text="AWS Developer Blog" title="AWS Developer Blog" htmlUrl="https://aws.amazon.com/blogs/developer/" xmlUrl="https://aws.amazon.com/blogs/developer/feed" />
+            <outline type="rss" text="Desktop and Application Streaming" title="Desktop and Application Streaming" htmlUrl="https://aws.amazon.com/blogs/desktop-and-application-streaming/" xmlUrl="https://aws.amazon.com/blogs/desktop-and-application-streaming/feed" />
+            <outline type="rss" text="AWS Developer Tools Blog" title="AWS Developer Tools Blog" htmlUrl="https://aws.amazon.com/blogs/developer/" xmlUrl="https://aws.amazon.com/blogs/developer/feed" />
             <outline type="rss" text="AWS DevOps Blog" title="AWS DevOps Blog" htmlUrl="https://aws.amazon.com/blogs/devops/" xmlUrl="https://aws.amazon.com/blogs/devops/feed" />
             <outline type="rss" text="AWS Cloud Enterprise Strategy Blog" title="AWS Cloud Enterprise Strategy Blog" htmlUrl="https://aws.amazon.com/blogs/enterprise-strategy/" xmlUrl="https://aws.amazon.com/blogs/enterprise-strategy/feed" />
             <outline type="rss" text="AWS Game Tech Blog" title="AWS Game Tech Blog" htmlUrl="https://aws.amazon.com/blogs/gametech/" xmlUrl="https://aws.amazon.com/blogs/gametech/feed" />
-            <outline type="rss" text="AWS The Internet of Things Blog" title="AWS The Internet of Things Blog" htmlUrl="https://aws.amazon.com/blogs/iot/" xmlUrl="https://aws.amazon.com/blogs/iot/feed" />
+            <outline type="rss" text="AWS HPC Blog" title="AWS HPC Blog" htmlUrl="https://aws.amazon.com/blogs/hpc/" xmlUrl="https://aws.amazon.com/blogs/hpc/feed" />
+            <outline type="rss" text="Infrastructure &amp; Automation" title="Infrastructure &amp; Automation" htmlUrl="https://aws.amazon.com/blogs/infrastructure-and-automation/" xmlUrl="https://aws.amazon.com/blogs/infrastructure-and-automation/feed" />
+            <outline type="rss" text="AWS for Industrie" title="AWS for Industrie" htmlUrl="https://aws.amazon.com/blogs/industries/" xmlUrl="https://aws.amazon.com/blogs/industries/feed"/>
+            <outline type="rss" text="The Internet of Things on AWS – Official Blog" title="The Internet of Things on AWS – Official Blog" htmlUrl="https://aws.amazon.com/blogs/iot/" xmlUrl="https://aws.amazon.com/blogs/iot/feed" />
             <outline type="rss" text="AWS Machine Learning Blog" title="AWS Machine Learning Blog" htmlUrl="https://aws.amazon.com/blogs/machine-learning/" xmlUrl="https://aws.amazon.com/blogs/machine-learning/feed" />
-            <outline type="rss" text="AWS Management Tools Blog" title="AWS Management Tools Blog" htmlUrl="https://aws.amazon.com/blogs/mt/" xmlUrl="https://aws.amazon.com/blogs/mt/feed" />
+            <outline type="rss" text="AWS Management &amp; Governance Blog" title="AWS Management &amp; Governance Blog" htmlUrl="https://aws.amazon.com/blogs/mt/" xmlUrl="https://aws.amazon.com/blogs/mt/feed" />
             <outline type="rss" text="AWS Media Blog" title="AWS Media Blog" htmlUrl="https://aws.amazon.com/blogs/media/" xmlUrl="https://aws.amazon.com/blogs/media/feed" />
-            <outline type="rss" text="AWS Messaging and Targeting Blog" title="AWS Messaging and Targeting Blog" htmlUrl="https://aws.amazon.com/blogs/messaging-and-targeting/" xmlUrl="https://aws.amazon.com/blogs/messaging-and-targeting/feed" />
-            <outline type="rss" text="AWS Mobile Blog" title="AWS Mobile Blog" htmlUrl="https://aws.amazon.com/blogs/mobile/" xmlUrl="https://aws.amazon.com/blogs/mobile/feed" />
-            <outline type="rss" text="AWS Networking and Content Delivery" title="AWS Networking and Content Delivery" htmlUrl="https://aws.amazon.com/blogs/networking-and-content-delivery/" xmlUrl="https://aws.amazon.com/blogs/networking-and-content-delivery/feed" />
+            <outline type="rss" text="AWS Messaging &amp; Targeting Blog" title="AWS Messaging &amp; Targeting Blog" htmlUrl="https://aws.amazon.com/blogs/messaging-and-targeting/" xmlUrl="https://aws.amazon.com/blogs/messaging-and-targeting/feed" />
+
+            <outline type="rss" text="Windows on AWS" title="Windows on AWS" htmlUrl="https://aws.amazon.com/blogs/modernizing-with-aws/" xmlUrl="https://aws.amazon.com/blogs/modernizing-with-aws/feed"/>
+            <outline type="rss" text="Front-End Web &amp; Mobile" title="Front-End Web &amp; Mobile" htmlUrl="https://aws.amazon.com/blogs/mobile/" xmlUrl="https://aws.amazon.com/blogs/mobile/feed" />
+            <outline type="rss" text="Networking &amp; Content Delivery" title="Networking &amp; Content Delivery" htmlUrl="https://aws.amazon.com/blogs/networking-and-content-delivery/" xmlUrl="https://aws.amazon.com/blogs/networking-and-content-delivery/feed" />
             <outline type="rss" text="AWS Open Source Blog" title="AWS Open Source Blog" htmlUrl="https://aws.amazon.com/blogs/opensource/" xmlUrl="https://aws.amazon.com/blogs/opensource/feed" />
-            <outline type="rss" text="AWS Government, Education, and Nonprofits Blog" title="AWS Government, Education, and Nonprofits Blog" htmlUrl="https://aws.amazon.com/blogs/publicsector/" xmlUrl="https://aws.amazon.com/blogs/publicsector/feed" />
+            <outline type="rss" text="AWS Public Sector Blog" title="AWS Public Sector Blog" htmlUrl="https://aws.amazon.com/blogs/publicsector/" xmlUrl="https://aws.amazon.com/blogs/publicsector/feed" />
+            <outline type="rss" text="AWS Quantum Computing Blog" title="AWS Quantum Computing Blog" htmlUrl="https://aws.amazon.com/blogs/quantum-computing/" xmlUrl="https://aws.amazon.com/blogs/quantum-computing/feed"/>
+            <outline type="rss" text="AWS Robotics Blog" text="AWS Robotics Blog" htmlUrl="https://aws.amazon.com/blogs/robotics/" xmlUrl="https://aws.amazon.com/blogs/robotics/feed" />
             <outline type="rss" text="AWS for SAP" title="AWS for SAP" htmlUrl="https://aws.amazon.com/blogs/awsforsap/" xmlUrl="https://aws.amazon.com/blogs/awsforsap/feed" />
             <outline type="rss" text="AWS Security Blog" title="AWS Security Blog" htmlUrl="https://aws.amazon.com/blogs/security/" xmlUrl="https://aws.amazon.com/blogs/security/feed" />
             <outline type="rss" text="AWS Startups Blog" title="AWS Startups Blog" htmlUrl="https://aws.amazon.com/blogs/startups/" xmlUrl="https://aws.amazon.com/blogs/startups/feed" />
             <outline type="rss" text="AWS Japan Blog" title="AWS Japan Blog" htmlUrl="https://aws.amazon.com/jp/blogs/news/" xmlUrl="https://aws.amazon.com/jp/blogs/news/feed" />
+            <outline type="rss" text="AWS Training and Certification Blog" title="AWS Training and Certification Blog" htmlUrl="https://aws.amazon.com/blogs/training-and-certification/" xmlUrl="https://aws.amazon.com/blogs/training-and-certification/feed"/>
         </outline>
         <outline text="AWS Youtube Channel" title="AWS Youtube Channel">
             <outline type="rss" text="AWS" title="AWS" htmlUrl="https://www.youtube.com/user/AmazonWebServices" xmlUrl="https://www.youtube.com/feeds/videos.xml?user=AmazonWebServices" />
@@ -35,9 +47,9 @@
         </outline>
         <outline text="AWS Podcast" title="AWS Podcast">
             <outline type="rss" text="AWS Podcast" title="AWS Podcast" htmlUrl="https://aws.amazon.com/jp/podcasts/aws-podcast/" xmlUrl="https://d3gih7jbfe3jlq.cloudfront.net/aws-podcast.rss" />
-        </outline>        
+        </outline>
         <outline text="AWS Security" title="AWS Security">
             <outline type="rss" text="Amazon Linux Security Center" title="Amazon Linux Security Center" htmlUrl="https://alas.aws.amazon.com/" xmlUrl="https://alas.aws.amazon.com/alas.rss" />
-        </outline>        
+        </outline>
     </body>
 </opml>


### PR DESCRIPTION
# Summary

ref: https://aws.amazon.com/blogs/aws/

I changed as follows:

- If the page title is updated, change both `title` and `text`
- Add missing blog sources

 https://aws.amazon.com/blogs/aws/ に記載されているブログリンクを元に足らないリソースを追加しました。またRSSフィードをみてタイトルが更新されている場合はタイトルを更新しました。他にも必要な作業があればご教授ください 🙏 

# Test

- Import the OPML file via feedly and confirmed it works well

![image](https://user-images.githubusercontent.com/1884908/122037522-9d128500-ce0f-11eb-84c7-a6fc0fde7308.png)
